### PR TITLE
Add support for callables

### DIFF
--- a/src/Widget/ExplanationField.php
+++ b/src/Widget/ExplanationField.php
@@ -21,8 +21,12 @@ class ExplanationField extends Widget
     {
         parent::__construct($attributes);
 
-        if (isset($attributes['text_callback']) && \is_array($callback = $attributes['text_callback'])) {
-            $this->text = System::importStatic($callback[0])->{$callback[1]}($attributes);
+        if ($callback = ($attributes['text_callback'] ?? null)) {
+            if (\is_callable($callback)) {
+                $this->text = $callback($attributes);
+            } elseif (\is_array($callback)) {
+                $this->text = System::importStatic($callback[0])->{$callback[1]}($attributes);
+            }
         }
 
         if (isset($attributes['collapsible']) && true === $attributes['collapsible']) {


### PR DESCRIPTION
This PR adds support for callables, so that you could do the following:

```php
$GLOBALS['TL_DCA']['tl_content']['fields']['explanation'] = [
    'inputType' => 'explanation',
    'eval' => [
        'text_callback' => static function(array $attributes): string {
            return match ($attributes['dataContainer']?->activeRecord->type ?? null) {
                'headline' => 'Headline explanation.',
                'text' => 'Text explanation.'
            };
        },
    ],
];